### PR TITLE
Update naver_movie_review.ipynb

### DIFF
--- a/ch08/naver_movie_review.ipynb
+++ b/ch08/naver_movie_review.ipynb
@@ -691,7 +691,8 @@
       "source": [
         "from sklearn.model_selection import RandomizedSearchCV\n",
         "from sklearn.linear_model import SGDClassifier\n",
-        "from sklearn.utils.fixes import loguniform\n",
+        "#from sklearn.utils.fixes import loguniform\n",
+        "from scipy.stats import loguniform\n",
         "\n",
         "# 사이킷런 1.3버전을 사용하는 경우 'log'를 'log_loss'로 바꾸어 사용하세요.\n",
         "sgd = SGDClassifier(loss='log', random_state=1)\n",


### PR DESCRIPTION
구글코랩에서 사이킷런 1.3버전을 사용하는 경우 'log'를 'log_loss'로 바꾸어 사용하고  
 from sklearn.utils.fixes import loguniform 을
 from scipy.stats import loguniform 로 바꾸니 동작이 되네요
 sgd = SGDClassifier(loss='log_loss', random_state=1)